### PR TITLE
Create CPDAcknowledgements.h

### DIFF
--- a/CPDAcknowledgements/CPDAcknowledgements.h
+++ b/CPDAcknowledgements/CPDAcknowledgements.h
@@ -1,0 +1,16 @@
+//
+//  CPDAcknowledgements
+//  Umbrella Header to allow for Swift ModuleMap Creation
+//
+//  Created by Lindsay Adland on 18/6/16.
+//  Copyright © 2016 ClosedCaption. All rights reserved.
+
+#ifndef CPDAcknowledgements_h
+#define CPDAcknowledgements_h
+
+#import "CPDAcknowledgementsViewController.h"
+#import "CPDContribution.h"
+#import "CPDLibrary.h"
+#import "CPDStyle.h"
+
+#endif


### PR DESCRIPTION
Created Umbrella Header to allow for Swift ModuleMap Creation.

ModuleMap creation required to allow the pod to be used in Swift projects