### PR TITLE
Increase iOS deployment target to 9.0 the minimum supported by Xcode 12.

### DIFF
--- a/CPDAcknowledgements.podspec
+++ b/CPDAcknowledgements.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/CocoaPods/CPDAcknowledgements.git", :tag => s.version.to_s }
   s.homepage      = "https://github.com/CocoaPods/CPDAcknowledgements"
   s.social_media_url = "https://twitter.com/CocoaPods"
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
   s.source_files = 'CPDAcknowledgements/**/**'
   s.private_header_files = 'CPDAcknowledgements/private/*.h'
   s.ios.frameworks = 'UIKit'


### PR DESCRIPTION
Fixes #9.